### PR TITLE
Fix writing val > 255 and fix brightness function while loop

### DIFF
--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -100,7 +100,7 @@ class Backlight:
             raise e
 
     def _normalize_brightness(self, value: float) -> int:
-       return max(min(100, int(round(value / self._max_brightness * 100))), 0)
+        return max(min(100, int(round(value / self._max_brightness * 100))), 0)
 
     def _denormalize_brightness(self, value: float) -> int:
         return max(min(255, int(round(value * self._max_brightness / 100))), 0)

--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -182,7 +182,11 @@ class Backlight:
             current_value = self.brightness
             step = 1 if current_value < value else -1
             diff = abs(value - current_value)
-            while 0.0 <= current_value and current_value != value and current_value <= 100.0:
+            while (
+                0.0 <= current_value 
+                and current_value != value 
+                and current_value <= 100.0
+            ):
                 current_value += step
                 if self._board_type == BoardType.RASPBERRY_PI:
                     self._set_value(

--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -183,8 +183,8 @@ class Backlight:
             step = 1 if current_value < value else -1
             diff = abs(value - current_value)
             while (
-                0.0 <= current_value 
-                and current_value != value 
+                0.0 <= current_value
+                and current_value != value
                 and current_value <= 100.0
             ):
                 current_value += step

--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -100,15 +100,9 @@ class Backlight:
             raise e
 
     def _normalize_brightness(self, value: float) -> int:
-        print(f"Original: {int(round(value / self._max_brightness * 100))}")
-        print(f"Mod: {max(min(100, int(round(value / self._max_brightness * 100))), 0)}")
-        #return int(round(value / self._max_brightness * 100))
-        return max(min(100, int(round(value / self._max_brightness * 100))), 0)
+       return max(min(100, int(round(value / self._max_brightness * 100))), 0)
 
     def _denormalize_brightness(self, value: float) -> int:
-        print(f"Original: {int(round(value * self._max_brightness / 100))}")
-        print(f"Mod: {max(min(255, int(round(value * 255 / 100))), 0)}")
-        #return int(round(value * self._max_brightness / 100))
         return max(min(255, int(round(value * self._max_brightness / 100))), 0)
 
     @contextmanager

--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -100,10 +100,16 @@ class Backlight:
             raise e
 
     def _normalize_brightness(self, value: float) -> int:
-        return int(round(value / self._max_brightness * 100))
+        print(f"Original: {int(round(value / self._max_brightness * 100))}")
+        print(f"Mod: {max(min(100, int(round(value / self._max_brightness * 100))), 0)}")
+        #return int(round(value / self._max_brightness * 100))
+        return max(min(100, int(round(value / self._max_brightness * 100))), 0)
 
     def _denormalize_brightness(self, value: float) -> int:
-        return int(round(value * self._max_brightness / 100))
+        print(f"Original: {int(round(value * self._max_brightness / 100))}")
+        print(f"Mod: {max(min(255, int(round(value * 255 / 100))), 0)}")
+        #return int(round(value * self._max_brightness / 100))
+        return max(min(255, int(round(value * self._max_brightness / 100))), 0)
 
     @contextmanager
     def fade(self, duration: float) -> Generator:
@@ -182,7 +188,7 @@ class Backlight:
             current_value = self.brightness
             step = 1 if current_value < value else -1
             diff = abs(value - current_value)
-            while current_value != value:
+            while 0.0 <= current_value and current_value != value and current_value <= 100.0:
                 current_value += step
                 if self._board_type == BoardType.RASPBERRY_PI:
                     self._set_value(


### PR DESCRIPTION
- Function _denormalize_brightness does not clamp the output to the normal 0-255 int() range. Force-clamped 0-255 now.
- Function _normalize_brightness does not clamp the output to the normal 0-100 percent range. Force-clamped 0-100 now.
- In @brightness.setter, the while loop looks only for current_value != value. In some circumstances, it won't stop incrementing.  Now while loop is hard-clamped to 0-100 percent range and becomes False if current_value exceeds limits.